### PR TITLE
More conservative timeouts and retry stop times

### DIFF
--- a/zyte_api/aio/client.py
+++ b/zyte_api/aio/client.py
@@ -19,6 +19,9 @@ from ..stats import AggStats, ResponseStats
 from ..utils import user_agent
 
 
+# 120 seconds is probably too long, but we are concerned about the case with
+# many concurrent requests and some processing logic running in the same reactor,
+# thus, saturating the CPU. This will make timeouts more likely.
 AIO_API_TIMEOUT = aiohttp.ClientTimeout(total=API_TIMEOUT + 120)
 
 

--- a/zyte_api/aio/client.py
+++ b/zyte_api/aio/client.py
@@ -19,7 +19,7 @@ from ..stats import AggStats, ResponseStats
 from ..utils import user_agent
 
 
-AIO_API_TIMEOUT = aiohttp.ClientTimeout(total=max(API_TIMEOUT, 60) * 5)
+AIO_API_TIMEOUT = aiohttp.ClientTimeout(total=API_TIMEOUT + 120)
 
 
 def create_session(connection_pool_size=100, **kwargs) -> aiohttp.ClientSession:

--- a/zyte_api/aio/client.py
+++ b/zyte_api/aio/client.py
@@ -18,9 +18,8 @@ from ..constants import API_URL, API_TIMEOUT
 from ..stats import AggStats, ResponseStats
 from ..utils import user_agent
 
-AIO_API_TIMEOUT = aiohttp.ClientTimeout(total=API_TIMEOUT + 60,
-                                        sock_read=API_TIMEOUT + 30,
-                                        sock_connect=10)
+
+AIO_API_TIMEOUT = aiohttp.ClientTimeout(total=max(API_TIMEOUT, 60) * 5)
 
 
 def create_session(connection_pool_size=100, **kwargs) -> aiohttp.ClientSession:

--- a/zyte_api/aio/retry.py
+++ b/zyte_api/aio/retry.py
@@ -75,9 +75,9 @@ class RetryFactory:
         # wait 20-40s again
         wait_fixed(20) + wait_random(0, 20),
 
-        # wait from 30 to 330s, with full jitter and exponentially
+        # wait from 30 to 630s, with full jitter and exponentially
         # increasing max wait time
-        wait_fixed(30) + wait_random_exponential(multiplier=1, max=300)
+        wait_fixed(30) + wait_random_exponential(multiplier=1, max=600)
     )
 
     # connection errors, other client and server failures
@@ -87,7 +87,7 @@ class RetryFactory:
     )
     # temporary_download_error_wait = network_error_wait
     throttling_stop = stop_never
-    network_error_stop = stop_after_delay(2 * 60)  # was: 15*60
+    network_error_stop = stop_after_delay(15 * 60)
     # temporary_download_error_stop = stop_after_delay(15 * 60)
 
     def wait(self, retry_state: RetryCallState) -> float:

--- a/zyte_api/aio/retry.py
+++ b/zyte_api/aio/retry.py
@@ -87,7 +87,7 @@ class RetryFactory:
     )
     # temporary_download_error_wait = network_error_wait
     throttling_stop = stop_never
-    network_error_stop = stop_after_delay(15 * 60)
+    network_error_stop = stop_after_delay(5 * 60)
     # temporary_download_error_stop = stop_after_delay(15 * 60)
 
     def wait(self, retry_state: RetryCallState) -> float:


### PR DESCRIPTION
Existing timeouts favour interactivity. But IMHO they won't be good defaults for the use case of using the client at scale in a spider or service with high parallelism where too low timeouts can cause requests to be lost under high-pressure conditions. I propose then to set up a more conservative setup by raising the timeouts.

Any particular project requiring a different timeout structure can modify these defaults.