### PR TITLE
[RFC] Propose a minimal specialization for extract

### DIFF
--- a/zyte_api/aio/client.py
+++ b/zyte_api/aio/client.py
@@ -7,7 +7,7 @@ import time
 from base64 import b64decode
 from collections.abc import Mapping
 from functools import partial
-from typing import Awaitable, Iterator, List, Optional
+from typing import Awaitable, Iterator, List, Optional, Union
 
 import aiohttp
 from aiohttp import TCPConnector
@@ -20,6 +20,12 @@ from ..constants import API_URL, API_TIMEOUT
 from ..stats import AggStats, ResponseStats
 from ..utils import _to_lower_camel_case, user_agent
 
+
+class _NotLoaded:
+    pass
+
+
+_NOT_LOADED = _NotLoaded()
 
 # 120 seconds is probably too long, but we are concerned about the case with
 # many concurrent requests and some processing logic running in the same reactor,
@@ -56,6 +62,7 @@ class ExtractResult(Mapping):
 
     def __init__(self, api_response: dict):
         self._api_response = api_response
+        self._http_response_body: Union[bytes|_NotLoaded] = _NOT_LOADED
 
     def __getitem__(self, key):
         return self._api_response[key]
@@ -67,13 +74,12 @@ class ExtractResult(Mapping):
         return len(self._api_response)
 
     @property
-    def http_response_body(self): -> bytes:
-        if hasattr(self, "_http_response_body"):
-            return self._http_response_body
-        base64_body = self._api_response.get("httpResponseBody", None)
-        if base64_body is None:
-            raise ValueError("API response has no httpResponseBody key.")
-        self._http_response_body = b64decode(base64_body)
+    def http_response_body(self) -> Union[bytes|_NotLoaded]:
+        if self._http_response_body is _NOT_LOADED:
+            base64_body = self._api_response.get("httpResponseBody", None)
+            if base64_body is None:
+                raise ValueError("API response has no httpResponseBody key.")
+            self._http_response_body = b64decode(base64_body)
         return self._http_response_body
 
 
@@ -198,9 +204,9 @@ class AsyncClient:
         handle_retries: bool = True,
         retrying: Optional[AsyncRetrying] = None,
         **kwargs,
-    ) -> Awaitable[ExtractResult]:
+    ) -> ExtractResult:
         """…"""
-        query = self._build_extract_query({**kwargs, 'url'=url})
+        query = self._build_extract_query({**kwargs, 'url': url})
         response = await self.request_raw(
             query=query,
             endpoint='extract',

--- a/zyte_api/aio/client.py
+++ b/zyte_api/aio/client.py
@@ -4,8 +4,10 @@ Asyncio client for Zyte Data API
 
 import asyncio
 import time
+from base64 import b64decode
+from collections.abc import Mapping
 from functools import partial
-from typing import Optional, Iterator, List
+from typing import Awaitable, Iterator, List, Optional
 
 import aiohttp
 from aiohttp import TCPConnector
@@ -16,7 +18,7 @@ from .retry import zyte_api_retrying
 from ..apikey import get_apikey
 from ..constants import API_URL, API_TIMEOUT
 from ..stats import AggStats, ResponseStats
-from ..utils import user_agent
+from ..utils import _to_lower_camel_case, user_agent
 
 
 # 120 seconds is probably too long, but we are concerned about the case with
@@ -41,6 +43,38 @@ def _post_func(session):
                        timeout=AIO_API_TIMEOUT)
     else:
         return session.post
+
+
+class ExtractResult(Mapping):
+    """Result of a call to AsyncClient.extract.
+
+    It can be used as a dictionary to access the raw API response.
+
+    It also provides some helper properties for easier access to some of its
+    underlying data.
+    """
+
+    def __init__(self, api_response: dict):
+        self._api_response = api_response
+
+    def __getitem__(self, key):
+        return self._api_response[key]
+
+    def __iter__(self):
+        yield from self._api_response
+
+    def __len__(self):
+        return len(self._api_response)
+
+    @property
+    def http_response_body(self): -> bytes:
+        if hasattr(self, "_http_response_body"):
+            return self._http_response_body
+        base64_body = self._api_response.get("httpResponseBody", None)
+        if base64_body is None:
+            raise ValueError("API response has no httpResponseBody key.")
+        self._http_response_body = b64decode(base64_body)
+        return self._http_response_body
 
 
 class AsyncClient:
@@ -148,3 +182,44 @@ class AsyncClient:
                     session=session)
 
         return asyncio.as_completed([_request(query) for query in queries])
+
+    @staticmethod
+    def _build_extract_query(raw_query):
+        return {
+            _to_lower_camel_case(k): v
+            for k, v in raw_query.items()
+        }
+
+    async def extract(
+        self,
+        url: str,
+        *,
+        session: Optional[aiohttp.ClientSession] = None,
+        handle_retries: bool = True,
+        retrying: Optional[AsyncRetrying] = None,
+        **kwargs,
+    ) -> Awaitable[ExtractResult]:
+        """…"""
+        query = self._build_extract_query({**kwargs, 'url'=url})
+        response = await self.request_raw(
+            query=query,
+            endpoint='extract',
+            session=session,
+            handle_retries=handle_retries,
+            retrying=retrying,
+        )
+        return ExtractResult(response)
+
+    def extract_in_parallel(
+        self,
+        queries: List[dict],
+        *,
+        session: Optional[aiohttp.ClientSession] = None,
+    ) -> Iterator[asyncio.Future]:
+        """…"""
+        queries = [self._build_extract_query(query) for query in queries]
+        return self.request_parallel_as_completed(
+            queries,
+            endpoint='extract',
+            session=session,
+        )

--- a/zyte_api/utils.py
+++ b/zyte_api/utils.py
@@ -1,5 +1,11 @@
-# -*- coding: utf-8 -*-
 from .__version__ import __version__
+
+
+def _to_lower_camel_case(snake_case_string):
+    """Convert from snake case (foo_bar) to lower-case-initial camel case
+    (fooBar)."""
+    prefix, *rest = snake_case_string.split('_')
+    return prefix + ''.join(part.title() for part in rest)
 
 
 def user_agent(library):


### PR DESCRIPTION
This is a proposal for a specialization of the `AsyncClient.request_raw` method and its parallel counterpart for the `extract` endpoint.

It resolves #9, and only implements the 2 specialization features needed for that. But it is meant to set the base line for similar enhancements in the future.

To-do:

- [ ] Agree on the API (naming, initial and future features, forward-compatibility).
- [ ] Tests.
- [ ] Documentation.