### PR TITLE
add ClientConnectorError to the list of retried network exceptions

### DIFF
--- a/zyte_api/aio/retry.py
+++ b/zyte_api/aio/retry.py
@@ -38,6 +38,7 @@ _NETWORK_ERRORS = (
     client_exceptions.ServerTimeoutError,
     client_exceptions.ClientPayloadError,
     client_exceptions.ClientConnectorSSLError,
+    client_exceptions.ClientConnectorError,
 )
 
 


### PR DESCRIPTION
It seems asyncio may raise it sometimes. Docstring says this it
is raised if "connection to proxy can not be established", but this
seems to be wrong, and this error is not necessarily proxy-related.

I found this error by looking for "Cannot connect to host" error message which we've got in logs of a scraping job; see https://github.com/aio-libs/aiohttp/blob/1dbfbb433f3f7cd05ca97288805dec9e296d75de/aiohttp/client_exceptions.py#L150