### PR TITLE
clean up AggStats

### DIFF
--- a/zyte_api/aio/client.py
+++ b/zyte_api/aio/client.py
@@ -114,14 +114,11 @@ class AsyncClient:
         try:
             # Try to make a request
             result = await request()
-            self.agg_stats.n_extracted_queries += 1
+            self.agg_stats.n_success += 1
         except Exception:
             self.agg_stats.n_fatal_errors += 1
             raise
-        finally:
-            self.agg_stats.n_input_queries += 1
 
-        self.agg_stats.n_results += 1
         return result
 
     def request_parallel_as_completed(self,


### PR DESCRIPTION
* n_results is renamed to n_success;
* n_extracted_queries is removed, because it's always the same as
  n_results (i.e. n_success);
* n_input_queries is removed: it wasn't really a number of input queries,
  (it was a number of processed queries), and it can be computed
  from other stats: success + fatal errors;
* added a short comment which explains each stat value

This is technically backwards incompatible, but it shouldn't affect scrapy-zyte-api (until https://github.com/scrapy-plugins/scrapy-zyte-api/pull/33 is merged).

Fixes #23.
