### PR TITLE
add brotli as a dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+TBR
+---
+
+* Require to install ``Brotli`` as a dependency.
+
 0.3.0 (2022-07-29)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,11 @@ setup(
     install_requires=[
         'requests',
         'tenacity',
-        'aiohttp >= 3.6.0',
+        'aiohttp >= 3.7.3',
         'tqdm',
         'attrs',
         'runstats',
+        'brotli',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/zyte_api/aio/client.py
+++ b/zyte_api/aio/client.py
@@ -10,6 +10,7 @@ from typing import Optional, Iterator, List
 import aiohttp
 from aiohttp import TCPConnector
 from tenacity import AsyncRetrying
+from aiohttp.http_parser import HAS_BROTLI
 
 from .errors import RequestError
 from .retry import zyte_api_retrying
@@ -64,6 +65,12 @@ class AsyncClient:
         post = _post_func(session)
         auth = aiohttp.BasicAuth(self.api_key)
         headers = {'User-Agent': user_agent(aiohttp)}
+
+        # NOTE: Remove this check if the following commit for aiohttp which
+        # adds direct client support for brotli has been released after 3.8.1:
+        # https://github.com/aio-libs/aiohttp/commit/28ea32d2282728a94af73c87efd6ab314c14320e
+        if HAS_BROTLI:
+            headers['Accept-Encoding'] = 'br'
 
         response_stats = []
         start_global = time.perf_counter()

--- a/zyte_api/aio/client.py
+++ b/zyte_api/aio/client.py
@@ -10,7 +10,6 @@ from typing import Optional, Iterator, List
 import aiohttp
 from aiohttp import TCPConnector
 from tenacity import AsyncRetrying
-from aiohttp.http_parser import HAS_BROTLI
 
 from .errors import RequestError
 from .retry import zyte_api_retrying
@@ -64,13 +63,7 @@ class AsyncClient:
         retrying = retrying or zyte_api_retrying
         post = _post_func(session)
         auth = aiohttp.BasicAuth(self.api_key)
-        headers = {'User-Agent': user_agent(aiohttp)}
-
-        # NOTE: Remove this check if the following commit for aiohttp which
-        # adds direct client support for brotli has been released after 3.8.1:
-        # https://github.com/aio-libs/aiohttp/commit/28ea32d2282728a94af73c87efd6ab314c14320e
-        if HAS_BROTLI:
-            headers['Accept-Encoding'] = 'br'
+        headers = {'User-Agent': user_agent(aiohttp), 'Accept-Encoding': 'br'}
 
         response_stats = []
         start_global = time.perf_counter()


### PR DESCRIPTION
Resolves https://github.com/zytedata/python-zyte-api/issues/29

* bumped a dep to be at least `aiohttp >= 3.7.3` since `Brotli` replaced the old `brotlipy` dep which was unmaintained.
https://docs.aiohttp.org/en/stable/changes.html?highlight=brotli#id12
* Needed to add a small code to insert the `br` headers since the version with Brotli client support is not yet released.
https://github.com/aio-libs/aiohttp/commit/28ea32d2282728a94af73c87efd6ab314c14320e
    * Brotli decompression is fully supported, however.

We don't have automated tests that's set up yet, but I've tested this manually that:

- It sends `'Accept-Encoding': 'br'` when `brotli` is installed.
- It decompresses the response without any problem when `'Content-Encoding': 'br'` is received.