### PR TITLE
Update minimum aiohttp version. Fixes GH-35.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     install_requires=[
         'requests',
         'tenacity',
-        'aiohttp >= 3.7.3',
+        'aiohttp >= 3.8.0',
         'tqdm',
         'attrs',
         'runstats',


### PR DESCRIPTION
Fix #35. The wierd thing is that brotli support is mentioned in aiohttp 3.7.3 changelog. But anyways, bumping the version won't hurt. 