### PR TITLE
Don't reuse the connections.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changes
 =======
 
+(TBD)
+-----
+
+* Connections are no longer reused between requests.
+  This reduces the amount of ``ServerDisconnectedError`` exceptions.
+
 0.4.2 (2022-10-28)
 ------------------
 * Bump minimum ``aiohttp`` version to 3.8.0, as earlier versions don't support

--- a/zyte_api/aio/client.py
+++ b/zyte_api/aio/client.py
@@ -29,7 +29,8 @@ def create_session(connection_pool_size=100, **kwargs) -> aiohttp.ClientSession:
     """ Create a session with parameters suited for Zyte API """
     kwargs.setdefault('timeout', AIO_API_TIMEOUT)
     if "connector" not in kwargs:
-        kwargs["connector"] = TCPConnector(limit=connection_pool_size)
+        kwargs["connector"] = TCPConnector(limit=connection_pool_size,
+                                           force_close=True)
     return aiohttp.ClientSession(**kwargs)
 
 
@@ -132,9 +133,9 @@ class AsyncClient:
 
         ``queries`` is a list of requests to process (dicts).
 
-        ``session`` is an optional aiohttp.ClientSession object;
-        use it to enable HTTP Keep-Alive. Set the session TCPConnector
-        limit to a value greater than the number of connections.
+        ``session`` is an optional aiohttp.ClientSession object.
+        Set the session TCPConnector limit to a value greater than
+        the number of connections.
         """
         sem = asyncio.Semaphore(self.n_conn)
 


### PR DESCRIPTION
It seems aiohttp has troubles with edge cases of Keep-Alive (? not sure), and closing the TCP connection after each request helps with ServerDisconnectedErrors. I've been running multiple tests; ServerDisconnectedError can be reliably reproduced with current python-zyte-api, but I get none of them after this fix.

Using a single aiohttp session is still important, because it allows to reduce the number of ClientConnectorErrors.