### PR TITLE
Provide an option to store error responses in CLI

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-cov
 responses
+pytest-asyncio

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,11 +1,17 @@
-import asyncio
 import os
+from unittest.mock import Mock, patch, AsyncMock
 
 import pytest
 
 from zyte_api.__main__ import run
-from zyte_api.apikey import get_apikey
-from zyte_api.constants import API_URL
+from zyte_api.aio.errors import RequestError
+
+
+class RequestError(Exception):
+    @property
+    def parsed(self):
+        mock = Mock(response_body=Mock(decode=Mock(return_value=linkedin_response())))
+        return mock
 
 
 def is_file_not_empty(file_path):
@@ -26,78 +32,76 @@ def delete_file(file_path):
         print(f"File '{file_path}' not found. Unable to delete.")
 
 
-@pytest.mark.parametrize(
-    "queries,out,n_conn,stop_on_errors,retry_errors,store_errors",
-    (
-        # test if it stores the error(s) also by adding flag
-        (
-            [
-                {
-                    "url": "https://linkedin.com",
-                    "browserHtml": True,
-                    "echoData": "https://linkedin.com",
-                }
-            ],
-            open("test_response.jsonl", "w"),
-            20,
-            False,
-            True,
-            True,
-        ),
-    ),
-)
-def test_run_stores_error(
-    queries, out, n_conn, stop_on_errors, retry_errors, store_errors
-):
-    coro = run(
-        queries,
-        out=out,
-        n_conn=n_conn,
-        stop_on_errors=stop_on_errors,
-        api_url=API_URL,
-        api_key=get_apikey(),
-        retry_errors=retry_errors,
-        store_errors=store_errors,
-    )
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(coro)
-    assert is_file_not_empty(out.name) is True
-    delete_file(out.name)
+def linkedin_response():
+    response_str = '{"blockedDomain":"linkedin.com","type":"/download/domain-forbidden","title":"Domain Forbidden","status":451,"detail":"Extraction for the domain linkedin.com is forbidden."}'
+    return response_str
+
+
+async def fake_exception(value=True):
+    # Simulating an error condition
+    if value:
+        raise RequestError()
+
+    create_session_mock = AsyncMock()
+    return await create_session_mock.coroutine()
 
 
 @pytest.mark.parametrize(
-    "queries,out,n_conn,stop_on_errors,retry_errors,store_errors",
+    "queries,out",
     (
-        # test if it doesn't store the error(s)
         (
-            [
-                {
-                    "url": "https://linkedin.com",
-                    "browserHtml": True,
-                    "echoData": "https://linkedin.com",
-                }
-            ],
-            open("test_response.jsonl", "w"),
-            20,
-            False,
-            True,
-            False,
-        ),
+            # test if it stores the error(s) also by adding flag
+            (
+                [
+                    {
+                        "url": "https://linkedin.com",
+                        "browserHtml": True,
+                        "echoData": "https://linkedin.com",
+                    }
+                ],
+                open("test_response.jsonl", "w"),
+            ),
+        )
     ),
 )
-def test_run_dont_stores_error(
-    queries, out, n_conn, stop_on_errors, retry_errors, store_errors
-):
-    coro = run(
-        queries,
-        out=out,
-        n_conn=n_conn,
-        stop_on_errors=stop_on_errors,
-        api_url=API_URL,
-        api_key=get_apikey(),
-        retry_errors=retry_errors,
-        store_errors=store_errors,
-    )
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(coro)
-    assert not is_file_not_empty(out.name)
+@pytest.mark.asyncio
+async def test_run(queries, out):
+    n_conn = 5
+    stop_on_errors = False
+    api_url = "https://example.com"
+    api_key = "fake_key"
+    retry_errors = True
+    store_errors = True
+
+    # Create a mock for AsyncClient
+    async_client_mock = Mock()
+
+    # Create a mock for the request_parallel_as_completed method
+    request_parallel_mock = Mock()
+    async_client_mock.return_value.request_parallel_as_completed = request_parallel_mock
+
+    # Patch the AsyncClient class in __main__ with the mock
+    with patch("zyte_api.__main__.AsyncClient", async_client_mock), patch(
+        "zyte_api.__main__.create_session"
+    ) as create_session_mock:
+        # Mock create_session to return an AsyncMock
+        create_session_mock.return_value = AsyncMock()
+
+        # Set up the AsyncClient instance to return the mocked iterator
+        async_client_mock.return_value.request_parallel_as_completed.return_value = [
+            fake_exception(),
+        ]
+
+        # Call the run function with the mocked AsyncClient
+        await run(
+            queries=queries,
+            out=out,
+            n_conn=n_conn,
+            stop_on_errors=stop_on_errors,
+            api_url=api_url,
+            api_key=api_key,
+            retry_errors=retry_errors,
+            store_errors=store_errors,
+        )
+
+    assert is_file_not_empty(out.name)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,103 @@
+import asyncio
+import os
+
+import pytest
+
+from zyte_api.__main__ import run
+from zyte_api.apikey import get_apikey
+from zyte_api.constants import API_URL
+
+
+def is_file_not_empty(file_path):
+    try:
+        with open(file_path, "r") as file:
+            # Read the first character to check if the file is empty
+            first_char = file.read(1)
+            return bool(first_char)
+    except FileNotFoundError:
+        return False
+
+
+def delete_file(file_path):
+    try:
+        os.remove(file_path)
+        print(f"File '{file_path}' has been deleted successfully.")
+    except FileNotFoundError:
+        print(f"File '{file_path}' not found. Unable to delete.")
+
+
+@pytest.mark.parametrize(
+    "queries,out,n_conn,stop_on_errors,retry_errors,store_errors",
+    (
+        # test if it stores the error(s) also by adding flag
+        (
+            [
+                {
+                    "url": "https://linkedin.com",
+                    "browserHtml": True,
+                    "echoData": "https://linkedin.com",
+                }
+            ],
+            open("test_response.jsonl", "w"),
+            20,
+            False,
+            True,
+            True,
+        ),
+    ),
+)
+def test_run_stores_error(
+    queries, out, n_conn, stop_on_errors, retry_errors, store_errors
+):
+    coro = run(
+        queries,
+        out=out,
+        n_conn=n_conn,
+        stop_on_errors=stop_on_errors,
+        api_url=API_URL,
+        api_key=get_apikey(),
+        retry_errors=retry_errors,
+        store_errors=store_errors,
+    )
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(coro)
+    assert is_file_not_empty(out.name) is True
+    delete_file(out.name)
+
+
+@pytest.mark.parametrize(
+    "queries,out,n_conn,stop_on_errors,retry_errors,store_errors",
+    (
+        # test if it doesn't store the error(s)
+        (
+            [
+                {
+                    "url": "https://linkedin.com",
+                    "browserHtml": True,
+                    "echoData": "https://linkedin.com",
+                }
+            ],
+            open("test_response.jsonl", "w"),
+            20,
+            False,
+            True,
+            False,
+        ),
+    ),
+)
+def test_run_dont_stores_error(
+    queries, out, n_conn, stop_on_errors, retry_errors, store_errors
+):
+    coro = run(
+        queries,
+        out=out,
+        n_conn=n_conn,
+        stop_on_errors=stop_on_errors,
+        api_url=API_URL,
+        api_key=get_apikey(),
+        retry_errors=retry_errors,
+        store_errors=store_errors,
+    )
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(coro)
+    assert not is_file_not_empty(out.name)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -64,9 +64,9 @@ async def fake_exception(value=True):
             (
                 [
                     {
-                        "url": "https://linkedin.com",
+                        "url": "https://forbidden.example",
                         "browserHtml": True,
-                        "echoData": "https://linkedin.com",
+                        "echoData": "https://forbidden.example",
                     }
                 ],
                 forbidden_domain_response(),
@@ -77,9 +77,9 @@ async def fake_exception(value=True):
             (
                 [
                     {
-                        "url": "https://linkedin.com",
+                        "url": "https://forbidden.example",
                         "browserHtml": True,
-                        "echoData": "https://linkedin.com",
+                        "echoData": "https://forbidden.example",
                     }
                 ],
                 None,  # expected response should be None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,7 +4,6 @@ from unittest.mock import Mock, patch, AsyncMock
 import pytest
 
 from zyte_api.__main__ import run
-from zyte_api.aio.errors import RequestError
 
 
 class RequestError(Exception):

--- a/zyte_api/__main__.py
+++ b/zyte_api/__main__.py
@@ -63,12 +63,13 @@ async def run(
                 try:
                     result = await fut
                 except Exception as e:
-                    logger.error(str(e))
                     if store_errors:
                         write_output(e.parsed.response_body.decode())
 
                     if stop_on_errors:
                         raise
+
+                    logger.error(str(e))
                 else:
                     write_output(result)
                 finally:

--- a/zyte_api/__main__.py
+++ b/zyte_api/__main__.py
@@ -62,15 +62,15 @@ async def run(
             for fut in result_iter:
                 try:
                     result = await fut
-                    write_output(result)
                 except Exception as e:
-                    if stop_on_errors:
-                        raise
-
+                    logger.error(str(e))
                     if store_errors:
                         write_output(e.parsed.response_body.decode())
 
-                    logger.error(str(e))
+                    if stop_on_errors:
+                        raise
+                else:
+                    write_output(result)
                 finally:
                     pbar.set_postfix_str(str(client.agg_stats))
         finally:


### PR DESCRIPTION
- Make initial change to write error response as well when --store-errors flag is passed.

- Resolves https://github.com/zytedata/python-zyte-api/issues/38
- Not taking care of errors belong to python 3.7 as its support will be removed soon.