### PR TITLE
Add conservative_retrying

### DIFF
--- a/docs/ref/api.rst
+++ b/docs/ref/api.rst
@@ -26,7 +26,12 @@ Retries
 .. autodata:: zyte_api_retrying
     :no-value:
 
+.. autodata:: conservative_retrying
+    :no-value:
+
 .. autoclass:: RetryFactory
+
+.. autoclass:: ConservativeRetryFactory
 
 
 Errors

--- a/docs/ref/api.rst
+++ b/docs/ref/api.rst
@@ -26,12 +26,12 @@ Retries
 .. autodata:: zyte_api_retrying
     :no-value:
 
-.. autodata:: aggresive_retrying
+.. autodata:: aggressive_retrying
     :no-value:
 
 .. autoclass:: RetryFactory
 
-.. autoclass:: AggresiveRetryFactory
+.. autoclass:: AggressiveRetryFactory
 
 
 Errors

--- a/docs/ref/api.rst
+++ b/docs/ref/api.rst
@@ -26,12 +26,12 @@ Retries
 .. autodata:: zyte_api_retrying
     :no-value:
 
-.. autodata:: conservative_retrying
+.. autodata:: aggresive_retrying
     :no-value:
 
 .. autoclass:: RetryFactory
 
-.. autoclass:: ConservativeRetryFactory
+.. autoclass:: AggresiveRetryFactory
 
 
 Errors

--- a/docs/use/api.rst
+++ b/docs/use/api.rst
@@ -152,8 +152,8 @@ following:
 
 -   Retries :ref:`rate-limiting responses <zyte-api-rate-limit>` forever.
 
--   Retries :ref:`unsuccessful responses <zyte-api-unsuccessful-responses>` up
-    to 3 times.
+-   Retries :ref:`temporary download errors
+    <zyte-api-temporary-download-errors>` up to 3 times.
 
 -   Retries network errors for up to 15 minutes.
 

--- a/docs/use/api.rst
+++ b/docs/use/api.rst
@@ -182,8 +182,9 @@ and :class:`~zyte_api.AggressiveRetryFactory` features some examples of custom
 retry policies, and you can always build your own
 :class:`~tenacity.AsyncRetrying` object from scratch.
 
-To use :data:`~zyte_api.aggressive_retrying` or a custom retry policy, pass it
-when creating your client object:
+To use :data:`~zyte_api.aggressive_retrying` or a custom retry policy, pass an
+instance of your :class:`~tenacity.AsyncRetrying` subclass when creating your
+client object:
 
 .. code-block:: python
 

--- a/docs/use/api.rst
+++ b/docs/use/api.rst
@@ -173,9 +173,7 @@ policy as follows:
 -   Retries permanent download errors up to 3 times.
 
 -   Retries error responses with an HTTP status code in the 500-599 range (503,
-    520 and 521 excluded) until they have happened 4 times in a row, not
-    counting rate-limiting responses or network errors that may happen in
-    between.
+    520 and 521 excluded) up to 3 times.
 
 Alternatively, the reference documentation of :class:`~zyte_api.RetryFactory`
 and :class:`~zyte_api.AggressiveRetryFactory` features some examples of custom

--- a/docs/use/api.rst
+++ b/docs/use/api.rst
@@ -161,7 +161,7 @@ All retries are done with an exponential backoff algorithm.
 
 If some :ref:`unsuccessful responses <zyte-api-unsuccessful-responses>` exceed
 maximum retries with the default retry policy, try using
-:data:`~zyte_api.conservative_retrying` instead. Alternatively, the reference
+:data:`~zyte_api.aggresive_retrying` instead. Alternatively, the reference
 documentation of :class:`~zyte_api.RetryFactory` and
 :class:`~zyte_api.ConvervativeRetryFactory` features some examples of custom
 retry policies, and you can always build your own

--- a/docs/use/api.rst
+++ b/docs/use/api.rst
@@ -155,23 +155,41 @@ following:
 -   Retries :ref:`temporary download errors
     <zyte-api-temporary-download-errors>` up to 3 times.
 
--   Retries network errors for up to 15 minutes.
+-   Retries network errors until they have happened for 15 minutes straight.
 
 All retries are done with an exponential backoff algorithm.
 
+.. _aggressive-retry-policy:
+
 If some :ref:`unsuccessful responses <zyte-api-unsuccessful-responses>` exceed
 maximum retries with the default retry policy, try using
-:data:`~zyte_api.aggressive_retrying` instead. Alternatively, the reference
-documentation of :class:`~zyte_api.RetryFactory` and
-:class:`~zyte_api.ConvervativeRetryFactory` features some examples of custom
+:data:`~zyte_api.aggressive_retrying` instead, which modifies the default retry
+policy as follows:
+
+-   Temporary download error are retried 7 times. :ref:`Permanent download
+    errors <zyte-api-permanent-download-errors>` also count towards this retry
+    limit.
+
+-   Retries permanent download errors up to 3 times.
+
+-   Retries error responses with an HTTP status code in the 500-599 range (503,
+    520 and 521 excluded) until they have happened 4 times in a row, not
+    counting rate-limiting responses or network errors that may happen in
+    between.
+
+Alternatively, the reference documentation of :class:`~zyte_api.RetryFactory`
+and :class:`~zyte_api.AggressiveRetryFactory` features some examples of custom
 retry policies, and you can always build your own
 :class:`~tenacity.AsyncRetrying` object from scratch.
 
-To use a custom retry policy, pass it when creating your client object:
+To use :data:`~zyte_api.aggressive_retrying` or a custom retry policy, pass it
+when creating your client object:
 
 .. code-block:: python
 
-    client = ZyteAPI(retrying=custom_retrying)
+    from zyte_api import ZyteAPI, aggressive_retrying
+
+    client = ZyteAPI(retrying=aggressive_retrying)
 
 When retries are exceeded for a given request, an exception is raised. Except
 for the :meth:`~ZyteAPI.iter` method of the :ref:`sync API <sync>`, which

--- a/docs/use/api.rst
+++ b/docs/use/api.rst
@@ -161,7 +161,7 @@ All retries are done with an exponential backoff algorithm.
 
 If some :ref:`unsuccessful responses <zyte-api-unsuccessful-responses>` exceed
 maximum retries with the default retry policy, try using
-:data:`~zyte_api.aggresive_retrying` instead. Alternatively, the reference
+:data:`~zyte_api.aggressive_retrying` instead. Alternatively, the reference
 documentation of :class:`~zyte_api.RetryFactory` and
 :class:`~zyte_api.ConvervativeRetryFactory` features some examples of custom
 retry policies, and you can always build your own

--- a/docs/use/api.rst
+++ b/docs/use/api.rst
@@ -159,13 +159,19 @@ following:
 
 All retries are done with an exponential backoff algorithm.
 
-To customize the retry policy, create your own :class:`~tenacity.AsyncRetrying`
-object, e.g. using a custom subclass of :data:`~zyte_api.RetryFactory`, and
-pass it when creating your client object:
+If some :ref:`unsuccessful responses <zyte-api-unsuccessful-responses>` exceed
+maximum retries with the default retry policy, try using
+:data:`~zyte_api.conservative_retrying` instead. Alternatively, the reference
+documentation of :class:`~zyte_api.RetryFactory` and
+:class:`~zyte_api.ConvervativeRetryFactory` features some examples of custom
+retry policies, and you can always build your own
+:class:`~tenacity.AsyncRetrying` object from scratch.
+
+To use a custom retry policy, pass it when creating your client object:
 
 .. code-block:: python
 
-    client = ZyteAPI(retrying=custom_retry_policy)
+    client = ZyteAPI(retrying=custom_retrying)
 
 When retries are exceeded for a given request, an exception is raised. Except
 for the :meth:`~ZyteAPI.iter` method of the :ref:`sync API <sync>`, which

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -86,6 +86,9 @@ class DefaultResource(Resource):
             request.setResponseCode(429)
             response_data = {"status": 429, "type": "/limits/over-user-limit"}
             return json.dumps(response_data).encode()
+        if domain == "e500.example":
+            request.setResponseCode(500)
+            return ""
         if domain == "e520.example":
             request.setResponseCode(520)
             response_data = {"status": 520, "type": "/download/temporary-error"}

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock
 import pytest
 from tenacity import AsyncRetrying
 
-from zyte_api import AsyncZyteAPI, RequestError
+from zyte_api import AggressiveRetryFactory, AsyncZyteAPI, RequestError
 from zyte_api._retry import RetryFactory
 from zyte_api.aio.client import AsyncClient
 from zyte_api.apikey import NoApiKey
@@ -482,3 +482,10 @@ async def test_session_no_context_manager(mockserver):
             assert Exception in expected_results
         else:
             assert actual_result in expected_results
+
+
+def test_retrying_class():
+    """A descriptive exception is raised when creating a client with an
+    AsyncRetrying subclass or similar instead of an instance of it."""
+    with pytest.raises(ValueError):
+        AsyncZyteAPI(api_key="foo", retrying=AggressiveRetryFactory)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -2,16 +2,12 @@ import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
-from tenacity import AsyncRetrying
 
 from zyte_api import AggressiveRetryFactory, AsyncZyteAPI, RequestError
-from zyte_api._retry import RetryFactory
 from zyte_api.aio.client import AsyncClient
 from zyte_api.apikey import NoApiKey
 from zyte_api.errors import ParsedError
 from zyte_api.utils import USER_AGENT
-
-from .mockserver import DropResource, MockServer
 
 
 @pytest.mark.parametrize(
@@ -70,46 +66,6 @@ async def test_get(client_cls, get_method, mockserver):
         {"url": "https://a.example", "httpResponseBody": True}
     )
     assert actual_result == expected_result
-
-
-UNSET = object()
-
-
-class OutlierException(RuntimeError):
-    pass
-
-
-@pytest.mark.parametrize(
-    ("client_cls", "get_method"),
-    (
-        (AsyncZyteAPI, "get"),
-        (AsyncClient, "request_raw"),
-    ),
-)
-@pytest.mark.parametrize(
-    ("value", "exception"),
-    (
-        (UNSET, OutlierException),
-        (True, OutlierException),
-        (False, RequestError),
-    ),
-)
-@pytest.mark.asyncio
-async def test_get_handle_retries(client_cls, get_method, value, exception, mockserver):
-    kwargs = {}
-    if value is not UNSET:
-        kwargs["handle_retries"] = value
-
-    def broken_stop(_):
-        raise OutlierException
-
-    retrying = AsyncRetrying(stop=broken_stop)
-    client = client_cls(api_key="a", api_url=mockserver.urljoin("/"), retrying=retrying)
-    with pytest.raises(exception):
-        await getattr(client, get_method)(
-            {"url": "https://exception.example", "browserHtml": True},
-            **kwargs,
-        )
 
 
 @pytest.mark.parametrize(
@@ -232,132 +188,6 @@ async def test_iter(client_cls, iter_method, mockserver):
             assert Exception in expected_results
         else:
             assert actual_result in expected_results
-
-
-@pytest.mark.parametrize(
-    ("client_cls", "get_method"),
-    (
-        (AsyncZyteAPI, "get"),
-        (AsyncClient, "request_raw"),
-    ),
-)
-@pytest.mark.parametrize(
-    ("subdomain", "waiter"),
-    (
-        ("e429", "throttling"),
-        ("e520", "temporary_download_error"),
-    ),
-)
-@pytest.mark.asyncio
-async def test_retry_wait(client_cls, get_method, subdomain, waiter, mockserver):
-    def broken_wait(self, retry_state):
-        raise OutlierException
-
-    class CustomRetryFactory(RetryFactory):
-        pass
-
-    setattr(CustomRetryFactory, f"{waiter}_wait", broken_wait)
-
-    retrying = CustomRetryFactory().build()
-    client = client_cls(api_key="a", api_url=mockserver.urljoin("/"), retrying=retrying)
-    with pytest.raises(OutlierException):
-        await getattr(client, get_method)(
-            {"url": f"https://{subdomain}.example", "browserHtml": True},
-        )
-
-
-@pytest.mark.parametrize(
-    ("client_cls", "get_method"),
-    (
-        (AsyncZyteAPI, "get"),
-        (AsyncClient, "request_raw"),
-    ),
-)
-@pytest.mark.asyncio
-async def test_retry_wait_network_error(client_cls, get_method):
-    waiter = "network_error"
-
-    def broken_wait(self, retry_state):
-        raise OutlierException
-
-    class CustomRetryFactory(RetryFactory):
-        pass
-
-    setattr(CustomRetryFactory, f"{waiter}_wait", broken_wait)
-
-    retrying = CustomRetryFactory().build()
-    with MockServer(resource=DropResource) as mockserver:
-        client = client_cls(
-            api_key="a", api_url=mockserver.urljoin("/"), retrying=retrying
-        )
-        with pytest.raises(OutlierException):
-            await getattr(client, get_method)(
-                {"url": "https://example.com", "browserHtml": True},
-            )
-
-
-@pytest.mark.parametrize(
-    ("client_cls", "get_method"),
-    (
-        (AsyncZyteAPI, "get"),
-        (AsyncClient, "request_raw"),
-    ),
-)
-@pytest.mark.parametrize(
-    ("subdomain", "stopper"),
-    (
-        ("e429", "throttling"),
-        ("e520", "temporary_download_error"),
-    ),
-)
-@pytest.mark.asyncio
-async def test_retry_stop(client_cls, get_method, subdomain, stopper, mockserver):
-    def broken_stop(self, retry_state):
-        raise OutlierException
-
-    class CustomRetryFactory(RetryFactory):
-        def wait(self, retry_state):
-            return None
-
-    setattr(CustomRetryFactory, f"{stopper}_stop", broken_stop)
-
-    retrying = CustomRetryFactory().build()
-    client = client_cls(api_key="a", api_url=mockserver.urljoin("/"), retrying=retrying)
-    with pytest.raises(OutlierException):
-        await getattr(client, get_method)(
-            {"url": f"https://{subdomain}.example", "browserHtml": True},
-        )
-
-
-@pytest.mark.parametrize(
-    ("client_cls", "get_method"),
-    (
-        (AsyncZyteAPI, "get"),
-        (AsyncClient, "request_raw"),
-    ),
-)
-@pytest.mark.asyncio
-async def test_retry_stop_network_error(client_cls, get_method):
-    stopper = "network_error"
-
-    def broken_stop(self, retry_state):
-        raise OutlierException
-
-    class CustomRetryFactory(RetryFactory):
-        def wait(self, retry_state):
-            return None
-
-    setattr(CustomRetryFactory, f"{stopper}_stop", broken_stop)
-
-    retrying = CustomRetryFactory().build()
-    with MockServer(resource=DropResource) as mockserver:
-        client = client_cls(
-            api_key="a", api_url=mockserver.urljoin("/"), retrying=retrying
-        )
-        with pytest.raises(OutlierException):
-            await getattr(client, get_method)(
-                {"url": "https://example.com", "browserHtml": True},
-            )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -3,7 +3,7 @@ from copy import copy
 
 import pytest
 
-from zyte_api import RequestError, zyte_api_retrying
+from zyte_api import RequestError, aggresive_retrying, zyte_api_retrying
 
 
 def test_deprecated_imports():
@@ -63,6 +63,41 @@ FOREVER_TIMES = 100
                         mock_request_error(status=429),
                         mock_request_error(status=429),
                         mock_request_error(status=429),
+                        mock_request_error(status=520),
+                    ),
+                    True,
+                ),
+            )
+        ),
+        *(
+            (aggresive_retrying, exceptions, exhausted)
+            for exceptions, exhausted in (
+                (
+                    (mock_request_error(status=429),) * FOREVER_TIMES,
+                    False,
+                ),
+                (
+                    (mock_request_error(status=503),) * FOREVER_TIMES,
+                    False,
+                ),
+                (
+                    (mock_request_error(status=520),) * 7,
+                    False,
+                ),
+                (
+                    (mock_request_error(status=520),) * 8,
+                    True,
+                ),
+                (
+                    (
+                        *(mock_request_error(status=429),) * 6,
+                        mock_request_error(status=520),
+                    ),
+                    False,
+                ),
+                (
+                    (
+                        *(mock_request_error(status=429),) * 7,
                         mock_request_error(status=520),
                     ),
                     True,

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -23,6 +23,7 @@ def mock_request_error(*, status=200):
         request_info=None,
         response_content=None,
         status=status,
+        query={},
     )
 
 

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -52,18 +52,35 @@ FOREVER_TIMES = 100
                 ),
                 (
                     (
-                        mock_request_error(status=429),
-                        mock_request_error(status=429),
+                        *(mock_request_error(status=429),) * 2,
                         mock_request_error(status=520),
                     ),
                     False,
                 ),
                 (
                     (
-                        mock_request_error(status=429),
-                        mock_request_error(status=429),
-                        mock_request_error(status=429),
+                        *(mock_request_error(status=429),) * 3,
                         mock_request_error(status=520),
+                    ),
+                    False,
+                ),
+                (
+                    (
+                        *(
+                            mock_request_error(status=429),
+                            mock_request_error(status=520),
+                        )
+                        * 3,
+                    ),
+                    False,
+                ),
+                (
+                    (
+                        *(
+                            mock_request_error(status=429),
+                            mock_request_error(status=520),
+                        )
+                        * 4,
                     ),
                     True,
                 ),
@@ -99,6 +116,26 @@ FOREVER_TIMES = 100
                     (
                         *(mock_request_error(status=429),) * 7,
                         mock_request_error(status=520),
+                    ),
+                    False,
+                ),
+                (
+                    (
+                        *(
+                            mock_request_error(status=429),
+                            mock_request_error(status=520),
+                        )
+                        * 7,
+                    ),
+                    False,
+                ),
+                (
+                    (
+                        *(
+                            mock_request_error(status=429),
+                            mock_request_error(status=520),
+                        )
+                        * 8,
                     ),
                     True,
                 ),

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,3 +1,11 @@
+from collections import deque
+from copy import copy
+
+import pytest
+
+from zyte_api import RequestError, zyte_api_retrying
+
+
 def test_deprecated_imports():
     from zyte_api import RetryFactory, zyte_api_retrying
     from zyte_api.aio.retry import RetryFactory as DeprecatedRetryFactory
@@ -5,3 +13,90 @@ def test_deprecated_imports():
 
     assert RetryFactory is DeprecatedRetryFactory
     assert zyte_api_retrying is deprecated_zyte_api_retrying
+
+
+def mock_request_error(*, status=200):
+    return RequestError(
+        history=None,
+        request_info=None,
+        response_content=None,
+        status=status,
+    )
+
+
+# Number of times to test request errors that must be retried forever.
+FOREVER_TIMES = 100
+
+
+@pytest.mark.parametrize(
+    ("retrying", "exceptions", "exhausted"),
+    (
+        *(
+            (zyte_api_retrying, exceptions, exhausted)
+            for exceptions, exhausted in (
+                (
+                    (mock_request_error(status=429),) * FOREVER_TIMES,
+                    False,
+                ),
+                (
+                    (mock_request_error(status=503),) * FOREVER_TIMES,
+                    False,
+                ),
+                (
+                    (mock_request_error(status=520),) * 3,
+                    False,
+                ),
+                (
+                    (mock_request_error(status=520),) * 4,
+                    True,
+                ),
+                (
+                    (
+                        mock_request_error(status=429),
+                        mock_request_error(status=429),
+                        mock_request_error(status=520),
+                    ),
+                    False,
+                ),
+                (
+                    (
+                        mock_request_error(status=429),
+                        mock_request_error(status=429),
+                        mock_request_error(status=429),
+                        mock_request_error(status=520),
+                    ),
+                    True,
+                ),
+            )
+        ),
+    ),
+)
+@pytest.mark.asyncio
+async def test_retrying_attempt_based_stop(retrying, exceptions, exhausted):
+    """Test retry stops based on a number of attempts (as opposed to those
+    based on time passed)."""
+    last_exception = exceptions[-1]
+    exceptions = deque(exceptions)
+
+    def wait(retry_state):
+        return 0.0
+
+    retrying = copy(retrying)
+    retrying.wait = wait
+
+    async def run():
+        try:
+            exception = exceptions.popleft()
+        except IndexError:
+            return
+        else:
+            raise exception
+
+    run = retrying.wraps(run)
+    try:
+        await run()
+    except Exception as exception:
+        assert exhausted
+        assert exception == last_exception
+    else:
+        assert not exhausted

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -376,9 +376,7 @@ class fast_forward:
                     (*(mock_request_error(status=521),) * 4,),
                     True,
                 ),
-                # Undocumented 5xx errors are retried until they have happened
-                # 4 times in a row, not counting rate-limiting responses or
-                # network errors.
+                # Undocumented 5xx errors are retried up to 3 times.
                 *(
                     scenario
                     for status in (
@@ -419,7 +417,7 @@ class fast_forward:
                             (
                                 mock_request_error(status=status),
                                 mock_request_error(status=555),
-                                *(mock_request_error(status=status),) * 3,
+                                mock_request_error(status=status),
                             ),
                             False,
                         ),
@@ -427,7 +425,7 @@ class fast_forward:
                             (
                                 mock_request_error(status=status),
                                 mock_request_error(status=555),
-                                *(mock_request_error(status=status),) * 4,
+                                *(mock_request_error(status=status),) * 2,
                             ),
                             True,
                         ),

--- a/zyte_api/__init__.py
+++ b/zyte_api/__init__.py
@@ -4,11 +4,19 @@ Python client libraries and command line utilities for Zyte API
 
 from ._async import AsyncZyteAPI
 from ._errors import RequestError
-from ._retry import RetryFactory
+from ._retry import ConservativeRetryFactory, RetryFactory
+from ._retry import conservative_retrying as _conservative_retrying
 from ._retry import zyte_api_retrying as _zyte_api_retrying
 from ._sync import ZyteAPI
 from .errors import ParsedError
 
-# We re-define the variable here for Sphinx to pick the documentation.
+# We re-define the variables here for Sphinx to pick the documentation.
+
 #: :ref:`Default retry policy <default-retry-policy>`.
 zyte_api_retrying = _zyte_api_retrying
+
+#: Alternative :ref:`retry policy <retry-policy>` that builds on top of
+#: :data:`zyte_api_retrying`, but increases the number of attempts for
+#: temporary download errors from 4 to 16, and retries as temporary download
+#: errors any 5xx HTTP status code other than 503 (retried as rate-limiting).
+conservative_retrying = _conservative_retrying

--- a/zyte_api/__init__.py
+++ b/zyte_api/__init__.py
@@ -4,8 +4,8 @@ Python client libraries and command line utilities for Zyte API
 
 from ._async import AsyncZyteAPI
 from ._errors import RequestError
-from ._retry import ConservativeRetryFactory, RetryFactory
-from ._retry import conservative_retrying as _conservative_retrying
+from ._retry import AggresiveRetryFactory, RetryFactory
+from ._retry import aggresive_retrying as _aggresive_retrying
 from ._retry import zyte_api_retrying as _zyte_api_retrying
 from ._sync import ZyteAPI
 from .errors import ParsedError
@@ -19,4 +19,4 @@ zyte_api_retrying = _zyte_api_retrying
 #: :data:`zyte_api_retrying`, but increases the number of attempts for
 #: temporary download errors from 4 to 16, and retries as temporary download
 #: errors any 5xx HTTP status code other than 503 (retried as rate-limiting).
-conservative_retrying = _conservative_retrying
+aggresive_retrying = _aggresive_retrying

--- a/zyte_api/__init__.py
+++ b/zyte_api/__init__.py
@@ -4,8 +4,8 @@ Python client libraries and command line utilities for Zyte API
 
 from ._async import AsyncZyteAPI
 from ._errors import RequestError
-from ._retry import AggresiveRetryFactory, RetryFactory
-from ._retry import aggresive_retrying as _aggresive_retrying
+from ._retry import AggressiveRetryFactory, RetryFactory
+from ._retry import aggressive_retrying as _aggressive_retrying
 from ._retry import zyte_api_retrying as _zyte_api_retrying
 from ._sync import ZyteAPI
 from .errors import ParsedError
@@ -19,4 +19,4 @@ zyte_api_retrying = _zyte_api_retrying
 #: :data:`zyte_api_retrying`, but increases the number of attempts for
 #: temporary download errors from 4 to 16, and retries as temporary download
 #: errors any 5xx HTTP status code other than 503 (retried as rate-limiting).
-aggresive_retrying = _aggresive_retrying
+aggressive_retrying = _aggressive_retrying

--- a/zyte_api/__init__.py
+++ b/zyte_api/__init__.py
@@ -6,6 +6,12 @@ from ._async import AsyncZyteAPI
 from ._errors import RequestError
 from ._retry import AggressiveRetryFactory, RetryFactory
 from ._retry import aggressive_retrying as _aggressive_retrying
+from ._retry import (
+    stop_after_uninterrumpted_delay,
+    stop_on_count,
+    stop_on_download_error,
+    stop_on_uninterrupted_status,
+)
 from ._retry import zyte_api_retrying as _zyte_api_retrying
 from ._sync import ZyteAPI
 from .errors import ParsedError

--- a/zyte_api/__init__.py
+++ b/zyte_api/__init__.py
@@ -10,7 +10,6 @@ from ._retry import (
     stop_after_uninterrupted_delay,
     stop_on_count,
     stop_on_download_error,
-    stop_on_uninterrupted_status,
 )
 from ._retry import zyte_api_retrying as _zyte_api_retrying
 from ._sync import ZyteAPI

--- a/zyte_api/__init__.py
+++ b/zyte_api/__init__.py
@@ -7,7 +7,7 @@ from ._errors import RequestError
 from ._retry import AggressiveRetryFactory, RetryFactory
 from ._retry import aggressive_retrying as _aggressive_retrying
 from ._retry import (
-    stop_after_uninterrumpted_delay,
+    stop_after_uninterrupted_delay,
     stop_on_count,
     stop_on_download_error,
     stop_on_uninterrupted_status,

--- a/zyte_api/__init__.py
+++ b/zyte_api/__init__.py
@@ -20,8 +20,5 @@ from .errors import ParsedError
 #: :ref:`Default retry policy <default-retry-policy>`.
 zyte_api_retrying = _zyte_api_retrying
 
-#: Alternative :ref:`retry policy <retry-policy>` that builds on top of
-#: :data:`zyte_api_retrying`, but increases the number of attempts for
-#: temporary download errors from 4 to 16, and retries as temporary download
-#: errors any 5xx HTTP status code other than 503 (retried as rate-limiting).
+#: :ref:`Aggresive retry policy <aggressive-retry-policy>`.
 aggressive_retrying = _aggressive_retrying

--- a/zyte_api/_async.py
+++ b/zyte_api/_async.py
@@ -91,6 +91,11 @@ class AsyncZyteAPI:
         retrying: Optional[AsyncRetrying] = None,
         user_agent: Optional[str] = None,
     ):
+        if retrying is not None and not isinstance(retrying, AsyncRetrying):
+            raise ValueError(
+                "The retrying parameter, if defined, must be an instance of "
+                "AsyncRetrying."
+            )
         self.api_key = get_apikey(api_key)
         self.api_url = api_url
         self.n_conn = n_conn

--- a/zyte_api/_retry.py
+++ b/zyte_api/_retry.py
@@ -216,7 +216,7 @@ class AggresiveRetryFactory(RetryFactory):
         _maybe_temporary_error
     )
 
-    temporary_download_error_stop = stop_after_attempt(16)
+    temporary_download_error_stop = stop_after_attempt(8)
 
     def stop(self, retry_state: RetryCallState) -> bool:
         assert retry_state.outcome, "Unexpected empty outcome"

--- a/zyte_api/_retry.py
+++ b/zyte_api/_retry.py
@@ -69,9 +69,9 @@ class stop_on_count(stop_base):
 
     def __call__(self, retry_state: "RetryCallState") -> bool:
         if not hasattr(retry_state, "counter"):
-            retry_state.counter = Counter()
-        retry_state.counter[self._counter_name] += 1
-        if retry_state.counter[self._counter_name] >= self._max_count:
+            retry_state.counter = Counter()  # type: ignore
+        retry_state.counter[self._counter_name] += 1  # type: ignore
+        if retry_state.counter[self._counter_name] >= self._max_count:  # type: ignore
             return True
         return False
 
@@ -99,28 +99,28 @@ class stop_after_uninterrumpted_delay(stop_base):
 
     def __call__(self, retry_state: "RetryCallState") -> bool:
         if not hasattr(retry_state, "uninterrupted_start_times"):
-            retry_state.uninterrupted_start_times = {}
-        if self._timer_name not in retry_state.uninterrupted_start_times:
+            retry_state.uninterrupted_start_times = {}  # type: ignore
+        if self._timer_name not in retry_state.uninterrupted_start_times:  # type: ignore
             # First time.
-            retry_state.uninterrupted_start_times[self._timer_name] = [
+            retry_state.uninterrupted_start_times[self._timer_name] = [  # type: ignore
                 retry_state.attempt_number,
                 retry_state.outcome_timestamp,
             ]
             return False
-        attempt_number, start_time = retry_state.uninterrupted_start_times[
+        attempt_number, start_time = retry_state.uninterrupted_start_times[  # type: ignore
             self._timer_name
         ]
         if retry_state.attempt_number - attempt_number > 1:
             # There was a different stop reason since the last attempt,
             # resetting the timer.
-            retry_state.uninterrupted_start_times[self._timer_name] = [
+            retry_state.uninterrupted_start_times[self._timer_name] = [  # type: ignore
                 retry_state.attempt_number,
                 retry_state.outcome_timestamp,
             ]
             return False
         if retry_state.outcome_timestamp - start_time < self._max_delay:
             # Within time, do not stop, only increase the attempt count.
-            retry_state.uninterrupted_start_times[self._timer_name][0] += 1
+            retry_state.uninterrupted_start_times[self._timer_name][0] += 1  # type: ignore
             return False
         return True
 
@@ -272,16 +272,16 @@ class stop_on_download_error(stop_base):
 
     def __call__(self, retry_state: "RetryCallState") -> bool:
         if not hasattr(retry_state, "counter"):
-            retry_state.counter = Counter()
+            retry_state.counter = Counter()  # type: ignore
         assert retry_state.outcome, "Unexpected empty outcome"
         exc = retry_state.outcome.exception()
         assert exc, "Unexpected empty exception"
-        if exc.status == 521:
-            retry_state.counter["permanent_download_error"] += 1
-            if retry_state.counter["permanent_download_error"] >= self._max_permanent:
+        if exc.status == 521:  # type: ignore
+            retry_state.counter["permanent_download_error"] += 1  # type: ignore
+            if retry_state.counter["permanent_download_error"] >= self._max_permanent:  # type: ignore
                 return True
-        retry_state.counter["download_error"] += 1
-        if retry_state.counter["download_error"] >= self._max_total:
+        retry_state.counter["download_error"] += 1  # type: ignore
+        if retry_state.counter["download_error"] >= self._max_total:  # type: ignore
             return True
         return False
 
@@ -299,8 +299,8 @@ class stop_on_uninterrupted_status(stop_base):
         exc = retry_state.outcome.exception()
         assert exc, "Unexpected empty exception"
         count = 0
-        for status in reversed(retry_state.status_history):
-            if status == exc.status:
+        for status in reversed(retry_state.status_history):  # type: ignore
+            if status == exc.status:  # type: ignore
                 count += 1
                 if count >= self._max:
                     return True
@@ -353,8 +353,8 @@ class AggressiveRetryFactory(RetryFactory):
         exc = retry_state.outcome.exception()
         assert exc, "Unexpected empty exception"
         if not hasattr(retry_state, "status_history"):
-            retry_state.status_history = []
-        retry_state.status_history.append(getattr(exc, "status", -1))
+            retry_state.status_history = []  # type: ignore
+        retry_state.status_history.append(getattr(exc, "status", -1))  # type: ignore
         if _download_error(exc):
             return self.download_error_stop(retry_state)
         if _undocumented_error(exc):

--- a/zyte_api/_retry.py
+++ b/zyte_api/_retry.py
@@ -187,25 +187,25 @@ def is_maybe_temporary_error(exc: BaseException) -> bool:
     )
 
 
-class ConservativeRetryFactory(RetryFactory):
-    """Alternative factory class that builds :data:`conservative_retrying`.
+class AggresiveRetryFactory(RetryFactory):
+    """Alternative factory class that builds :data:`aggresive_retrying`.
 
-    To create a custom retry policy based on :data:`conservative_retrying`, you
+    To create a custom retry policy based on :data:`aggresive_retrying`, you
     can subclass this factory class, modify it as needed, and then call
     :meth:`build` on your subclass to get the corresponding
     :class:`tenacity.AsyncRetrying` object.
 
     For example, to increase the maximum number of attempts for errors treated
-    as temporary download errors by :data:`conservative_retrying` from 16 (i.e.
+    as temporary download errors by :data:`aggresive_retrying` from 16 (i.e.
     15 retries) to 32 (i.e. 31 retries):
 
     .. code-block:: python
 
         from tenacity import stop_after_attempt
-        from zyte_api import ConservativeRetryFactory
+        from zyte_api import AggresiveRetryFactory
 
 
-        class CustomRetryFactory(ConservativeRetryFactory):
+        class CustomRetryFactory(AggresiveRetryFactory):
             temporary_download_error_stop = stop_after_attempt(32)
 
 
@@ -235,4 +235,4 @@ class ConservativeRetryFactory(RetryFactory):
         return super().wait(retry_state)
 
 
-conservative_retrying = ConservativeRetryFactory().build()
+aggresive_retrying = AggresiveRetryFactory().build()

--- a/zyte_api/_retry.py
+++ b/zyte_api/_retry.py
@@ -85,7 +85,7 @@ def to_seconds(time_unit: time_unit_type) -> float:
     )
 
 
-class stop_after_uninterrumpted_delay(stop_base):
+class stop_after_uninterrupted_delay(stop_base):
     """Stop when this stop callable has been called for the specified time
     uninterrupted, i.e. without calls to different stop callables.
 
@@ -141,13 +141,13 @@ class RetryFactory:
 
         from zyte_api import (
             RetryFactory,
-            stop_after_uninterrumpted_delay,
+            stop_after_uninterrupted_delay,
             stop_on_count,
         )
 
 
         class CustomRetryFactory(RetryFactory):
-            network_error_stop = stop_after_uninterrumpted_delay(30 * 60)
+            network_error_stop = stop_after_uninterrupted_delay(30 * 60)
             temporary_download_error_stop = stop_on_count(8)
 
 
@@ -178,7 +178,7 @@ class RetryFactory:
     )
     temporary_download_error_wait = network_error_wait
     throttling_stop = stop_never
-    network_error_stop = stop_after_uninterrumpted_delay(15 * 60)
+    network_error_stop = stop_after_uninterrupted_delay(15 * 60)
     temporary_download_error_stop = stop_on_count(4)
 
     def wait(self, retry_state: RetryCallState) -> float:
@@ -294,7 +294,7 @@ class AggressiveRetryFactory(RetryFactory):
 
         from zyte_api import (
             AggressiveRetryFactory,
-            stop_after_uninterrumpted_delay,
+            stop_after_uninterrupted_delay,
             stop_on_download_error,
             stop_on_uninterrupted_status,
         )
@@ -302,7 +302,7 @@ class AggressiveRetryFactory(RetryFactory):
 
         class CustomRetryFactory(AggressiveRetryFactory):
             download_error_stop = stop_on_download_error(max_total=16, max_permanent=8)
-            network_error_stop = stop_after_uninterrumpted_delay(30 * 60)
+            network_error_stop = stop_after_uninterrupted_delay(30 * 60)
             undocumented_error_stop = stop_on_uninterrupted_status(8)
 
 

--- a/zyte_api/_retry.py
+++ b/zyte_api/_retry.py
@@ -179,7 +179,7 @@ class RetryFactory:
 zyte_api_retrying: AsyncRetrying = RetryFactory().build()
 
 
-def is_maybe_temporary_error(exc: BaseException) -> bool:
+def _maybe_temporary_error(exc: BaseException) -> bool:
     return (
         isinstance(exc, RequestError)
         and exc.status >= 500
@@ -213,7 +213,7 @@ class AggresiveRetryFactory(RetryFactory):
     """
 
     retry_condition = RetryFactory.retry_condition | retry_if_exception(
-        is_maybe_temporary_error
+        _maybe_temporary_error
     )
 
     temporary_download_error_stop = stop_after_attempt(16)
@@ -222,7 +222,7 @@ class AggresiveRetryFactory(RetryFactory):
         assert retry_state.outcome, "Unexpected empty outcome"
         exc = retry_state.outcome.exception()
         assert exc, "Unexpected empty exception"
-        if is_maybe_temporary_error(exc):
+        if _maybe_temporary_error(exc):
             return self.temporary_download_error_stop(retry_state)
         return super().stop(retry_state)
 
@@ -230,7 +230,7 @@ class AggresiveRetryFactory(RetryFactory):
         assert retry_state.outcome, "Unexpected empty outcome"
         exc = retry_state.outcome.exception()
         assert exc, "Unexpected empty exception"
-        if is_maybe_temporary_error(exc):
+        if _maybe_temporary_error(exc):
             return self.temporary_download_error_wait(retry_state=retry_state)
         return super().wait(retry_state)
 

--- a/zyte_api/_retry.py
+++ b/zyte_api/_retry.py
@@ -219,12 +219,18 @@ class ConservativeRetryFactory(RetryFactory):
     temporary_download_error_stop = stop_after_attempt(16)
 
     def stop(self, retry_state: RetryCallState) -> bool:
-        if is_maybe_temporary_error(retry_state.outcome.exception()):
+        assert retry_state.outcome, "Unexpected empty outcome"
+        exc = retry_state.outcome.exception()
+        assert exc, "Unexpected empty exception"
+        if is_maybe_temporary_error(exc):
             return self.temporary_download_error_stop(retry_state)
         return super().stop(retry_state)
 
     def wait(self, retry_state: RetryCallState) -> float:
-        if is_maybe_temporary_error(retry_state.outcome.exception()):
+        assert retry_state.outcome, "Unexpected empty outcome"
+        exc = retry_state.outcome.exception()
+        assert exc, "Unexpected empty exception"
+        if is_maybe_temporary_error(exc):
             return self.temporary_download_error_wait(retry_state=retry_state)
         return super().wait(retry_state)
 

--- a/zyte_api/_retry.py
+++ b/zyte_api/_retry.py
@@ -306,9 +306,6 @@ class AggressiveRetryFactory(RetryFactory):
         assert retry_state.outcome, "Unexpected empty outcome"
         exc = retry_state.outcome.exception()
         assert exc, "Unexpected empty exception"
-        if not hasattr(retry_state, "status_history"):
-            retry_state.status_history = []  # type: ignore
-        retry_state.status_history.append(getattr(exc, "status", -1))  # type: ignore
         if _download_error(exc):
             return self.download_error_stop(retry_state)
         if _undocumented_error(exc):


### PR DESCRIPTION
I feel like this alternative retry policy will be more useful to most projects. Since changing the default retry policy to something like this would require some discussion, I think it may be a good idea to implement it as an alternative ready-to-use retry policy, so that fewer users need to implement their own custom retry policy.