### PR TITLE
Disallow new requests after ≥10 and ≥1% undocumented error responses

### DIFF
--- a/docs/use/api.rst
+++ b/docs/use/api.rst
@@ -148,14 +148,20 @@ retries for :ref:`rate-limiting <zapi-rate-limit>` and :ref:`unsuccessful
 .. _default-retry-policy:
 
 The default retry policy, :data:`~zyte_api.zyte_api_retrying`, does the
-following:
+following for each request:
 
 -   Retries :ref:`rate-limiting responses <zapi-rate-limit>` forever.
 
--   Retries :ref:`temporary download errors
-    <zapi-temporary-download-errors>` up to 3 times.
+-   Retries :ref:`temporary download errors <zapi-temporary-download-errors>`
+    up to 3 times. :ref:`Permanent download errors
+    <zapi-permanent-download-errors>` also count towards this retry limit.
+
+-   Retries permanent download errors up to 3 times per request.
 
 -   Retries network errors until they have happened for 15 minutes straight.
+
+-   Retries error responses with an HTTP status code in the 500-599 range (503,
+    520 and 521 excluded) up to 3 times.
 
 All retries are done with an exponential backoff algorithm.
 
@@ -163,17 +169,8 @@ All retries are done with an exponential backoff algorithm.
 
 If some :ref:`unsuccessful responses <zapi-unsuccessful-responses>` exceed
 maximum retries with the default retry policy, try using
-:data:`~zyte_api.aggressive_retrying` instead, which modifies the default retry
-policy as follows:
-
--   Temporary download error are retried 7 times. :ref:`Permanent download
-    errors <zapi-permanent-download-errors>` also count towards this retry
-    limit.
-
--   Retries permanent download errors up to 3 times.
-
--   Retries error responses with an HTTP status code in the 500-599 range (503,
-    520 and 521 excluded) up to 3 times.
+:data:`~zyte_api.aggressive_retrying` instead, which duplicates attempts for
+all retry scenarios.
 
 Alternatively, the reference documentation of :class:`~zyte_api.RetryFactory`
 and :class:`~zyte_api.AggressiveRetryFactory` features some examples of custom

--- a/docs/use/api.rst
+++ b/docs/use/api.rst
@@ -163,6 +163,9 @@ following for each request:
 -   Retries error responses with an HTTP status code in the 500-599 range (503,
     520 and 521 excluded) up to 3 times.
 
+-   Disallows new requests if undocumented error responses are more than 10
+    *and* more than 1% of all responses.
+
 All retries are done with an exponential backoff algorithm.
 
 .. _aggressive-retry-policy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,6 @@ multi_line_output = 3
 
 [tool.black]
 target-version = ["py39", "py310", "py311", "py312", "py313"]
+
+[tool.mypy]
+check_untyped_defs = true

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,15 +11,6 @@ from zyte_api.__main__ import run
 from zyte_api.aio.errors import RequestError
 
 
-class MockRequestError(Exception):
-    @property
-    def parsed(self):
-        mock = Mock(
-            response_body=Mock(decode=Mock(return_value=forbidden_domain_response()))
-        )
-        return mock
-
-
 def get_json_content(file_object):
     if not file_object:
         return
@@ -53,7 +44,12 @@ def forbidden_domain_response():
 async def fake_exception(value=True):
     # Simulating an error condition
     if value:
-        raise MockRequestError()
+        raise RequestError(
+            query={"url": "https://example.com", "httpResponseBody": True},
+            response_content=json.dumps(forbidden_domain_response()).encode(),
+            request_info=None,
+            history=None,
+        )
 
     create_session_mock = AsyncMock()
     return await create_session_mock.coroutine()

--- a/zyte_api/__init__.py
+++ b/zyte_api/__init__.py
@@ -4,7 +4,7 @@ Python client libraries and command line utilities for Zyte API
 
 from ._async import AsyncZyteAPI
 from ._errors import RequestError
-from ._retry import AggressiveRetryFactory, RetryFactory
+from ._retry import AggressiveRetryFactory, RetryFactory, TooManyUndocumentedErrors
 from ._retry import aggressive_retrying as _aggressive_retrying
 from ._retry import (
     stop_after_uninterrupted_delay,

--- a/zyte_api/__main__.py
+++ b/zyte_api/__main__.py
@@ -11,6 +11,7 @@ from warnings import warn
 import tqdm
 from tenacity import retry_if_exception
 
+from zyte_api import RequestError
 from zyte_api._async import AsyncZyteAPI
 from zyte_api._retry import RetryFactory, _is_throttling_error
 from zyte_api._utils import create_session
@@ -71,13 +72,13 @@ async def run(
                 try:
                     result = await fut
                 except Exception as e:
-                    if store_errors:
-                        write_output(e.parsed.response_body.decode())
+                    if store_errors and isinstance(e, RequestError):
+                        write_output(e.parsed.data)
 
                     if stop_on_errors:
                         raise
 
-                    logger.error(str(e))
+                    logger.exception("Exception raised during response handling")
                 else:
                     write_output(result)
                 finally:

--- a/zyte_api/_errors.py
+++ b/zyte_api/_errors.py
@@ -31,11 +31,11 @@ class RequestError(ClientResponseError):
     @property
     def parsed(self):
         """Response as a :class:`ParsedError` object."""
-        return ParsedError.from_body(self.response_content)
+        return ParsedError.from_body(self.response_content or b"")
 
     def __str__(self):
         return (
             f"RequestError: {self.status}, message={self.message}, "
-            f"headers={self.headers}, body={self.response_content}, "
+            f"headers={self.headers}, body={self.response_content!r}, "
             f"request_id={self.request_id}"
         )

--- a/zyte_api/_retry.py
+++ b/zyte_api/_retry.py
@@ -192,9 +192,9 @@ class ZyteAsyncRetrying(AsyncRetrying):
 
     def __init__(
         self,
-        stop: "StopBaseT",
-        wait: "WaitBaseT",
-        retry: "SyncRetryBaseT | RetryBaseT",
+        stop: StopBaseT,
+        wait: WaitBaseT,
+        retry: SyncRetryBaseT | RetryBaseT,
         reraise: bool,
         **kwargs,
     ):

--- a/zyte_api/_retry.py
+++ b/zyte_api/_retry.py
@@ -224,8 +224,8 @@ class ZyteAsyncRetrying(AsyncRetrying):
                     if errors >= 10 and errors / total >= 0.01:
                         raise TooManyUndocumentedErrors(
                             outcome=exc,
-                            errors=errors,  # type: ignore[attr-defined]
-                            total=total,  # type: ignore[attr-defined]
+                            errors=errors,
+                            total=total,
                         )
         return do
 

--- a/zyte_api/stats.py
+++ b/zyte_api/stats.py
@@ -37,9 +37,9 @@ class AggStats:
         self.n_429 = 0  # number of 429 (throttling) responses
         self.n_errors = 0  # number of errors, including errors which were retried
 
-        self.status_codes = Counter()
-        self.exception_types = Counter()
-        self.api_error_types = Counter()
+        self.status_codes: Counter = Counter()
+        self.exception_types: Counter = Counter()
+        self.api_error_types: Counter = Counter()
 
     def __str__(self):
         return "conn:{:0.2f}s, resp:{:0.2f}s, throttle:{:.1%}, err:{}+{}({:.1%}) | success:{}/{}({:.1%})".format(


### PR DESCRIPTION
Continuation of https://github.com/Gallaecio/python-zyte-api/pull/1

It’s a rather hacky approach, to be honest:

-   The number of total responses and undocumented error responses is tracked in class variables. Tests involve monkey patching to reset or hard-code their values.

    -   If we want to keep the implementation at tenacity level, this is the cleanest path I saw, although I don’t discard there being better ways.

        The use of the class to count, instead of an instance, is due to tenacity creating copies of the instance for each function wrapping. The specifics are not completely clear to me, I am not 100% sure there is no way around it, but [this line seems problematic](https://github.com/jd/tenacity/blob/0d40e76f7d06d631fb127e1ec58c8bd776e70d49/tenacity/__init__.py#L334) for instance-based storage of these counters. The statistics on the next line are also not global, and [get reset on every wrapped call](https://github.com/jd/tenacity/blob/0d40e76f7d06d631fb127e1ec58c8bd776e70d49/tenacity/__init__.py#L348).

    - We could consider implementing this logic outside tenacity, in the client code. It would allow for a cleaner implementation, e.g. based on stats. The main issue I see, and it might be considered minor, is that then we cannot stop new requests as soon as the condition is met, we still need to wait for the retries of 1 of the on-going requests to finish, which means we may sometimes stop new requests only after e.g. 11+ and not only 10 undocumented error responses. There is also the issue of not being able to customize this logic through a custom retry policy class, but we might not want to support that to begin with, and if we did, we could instead provide some client parameter(s) instead.

I made some other decisions I’m not entirely sure about:

-   Did not make the aggressive retry policy behave any different here, i.e. it also stops new requests on ≥10 and ≥1%, and not on ≥20 and ≥2%.
-   Did not provide any facility to override these settings in custom retry policy classes, assuming we might want to discourage overriding this, while still allowing it.

Post-merge work:

- [ ] Prepare a PR for scrapy-zyte-api that closes a spider with a specific close reason upon getting the `TooManyUndocumentedErrors` exception.

