### PR TITLE
Allow setting params on the command line

### DIFF
--- a/zyte_api/constants.py
+++ b/zyte_api/constants.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 # Name of the environment variable with the API key
 ENV_VARIABLE = "ZYTE_API_KEY"
 
@@ -6,3 +8,10 @@ API_URL = "https://api.zyte.com/v1/"
 
 # Default timeout that server uses. Client timeouts should be larger than that.
 API_TIMEOUT = 200
+
+
+class URLConstant(Enum):
+    """Constants for URL"""
+
+    HTTP_RAW_RESPONSE = "httpResponseBody"
+    BROWSER_RESPONSE = "browserHtml"

--- a/zyte_api/utils.py
+++ b/zyte_api/utils.py
@@ -1,3 +1,4 @@
+import base64
 import re
 from pathlib import Path
 
@@ -19,6 +20,11 @@ def _guess_intype(file_name, lines):
         return "jl"
 
     return "txt"
+
+
+def _decode_raw_response(response):
+    raw = base64.b64decode(response["httpResponseBody"])
+    return raw.decode("utf-8")
 
 
 def _process_query(query):


### PR DESCRIPTION
- Add command line parameter to support response type. either as raw HTML or browser rendered HTML
- Add decode function to decode raw HTML code