### PR TITLE
Disallow new requests after ≥10 and ≥1% undocumented error responses

### DIFF
--- a/docs/ref/api.rst
+++ b/docs/ref/api.rst
@@ -40,5 +40,7 @@ Errors
 .. autoexception:: RequestError
     :members:
 
+.. autoexception:: TooManyUndocumentedErrors
+
 .. autoclass:: ParsedError
     :members:

--- a/docs/use/api.rst
+++ b/docs/use/api.rst
@@ -198,5 +198,22 @@ attempt to fail. Unsuccessful responses trigger a :exc:`RequestError` and
 network errors trigger :ref:`aiohttp exceptions <aiohttp-client-reference>`.
 Other exceptions could be raised; for example, from a custom retry policy.
 
+.. _zapi-undocumented-error-limit:
+
+Undocumented error limit
+========================
+
+.. versionadded:: VERSION
+
+Error responses with an HTTP status code in the 500-599 range (503, 520 and
+521 excluded) are usually a sign of an issue on the Zyte API side. Once a
+client has received 10 or more of them, and they account for 1% or more of the
+requests it has sent, that client stops sending requests: every call raises
+:exc:`~zyte_api.TooManyUndocumentedErrors` instead.
+
+The limit is per client object, so a new client can be used to resume sending
+requests. However, check https://status.zyte.com/ or contact `support
+<https://support.zyte.com/support/tickets/new>`_ first.
+
 
 .. seealso:: :ref:`api-ref`

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -7,7 +7,12 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from zyte_api import AggressiveRetryFactory, AsyncZyteAPI, RequestError
+from zyte_api import (
+    AggressiveRetryFactory,
+    AsyncZyteAPI,
+    RequestError,
+    TooManyUndocumentedErrors,
+)
 from zyte_api._utils import create_session
 from zyte_api.aio.client import AsyncClient
 from zyte_api.apikey import NoApiKey
@@ -366,3 +371,53 @@ def test_retrying_class():
     AsyncRetrying subclass or similar instead of an instance of it."""
     with pytest.raises(ValueError, match="must be an instance of AsyncRetrying"):
         AsyncZyteAPI(api_key="foo", retrying=AggressiveRetryFactory)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("status_codes", "n_attempts", "raises"),
+    (
+        # Undocumented error responses must be at least 10 and at least 1% of
+        # all attempts.
+        ({500: 9}, 9, False),
+        ({500: 10}, 10, True),
+        ({500: 10}, 1001, False),  # 0.999…%
+        ({500: 10}, 1000, True),  # 1%
+        # Rate-limiting and download errors do not count.
+        ({503: 10, 520: 10, 521: 10}, 30, False),
+    ),
+)
+@pytest.mark.asyncio
+async def test_too_many_undocumented_errors(
+    status_codes, n_attempts, raises, mockserver
+):
+    client = AsyncZyteAPI(api_key="a", api_url=mockserver.urljoin("/"))
+    client.agg_stats.status_codes.update(status_codes)
+    client.agg_stats.n_attempts = n_attempts
+    query = {"url": "https://a.example", "httpResponseBody": True}
+    if raises:
+        with pytest.raises(TooManyUndocumentedErrors):
+            await client.get(query)
+    else:
+        await client.get(query)
+
+
+@pytest.mark.asyncio
+async def test_too_many_undocumented_errors_e2e(mockserver):
+    client = AsyncZyteAPI(api_key="a", api_url=mockserver.urljoin("/"))
+    error_query = {"url": "https://e500.example", "httpResponseBody": True}
+    for _ in range(10):
+        with pytest.raises(RequestError):
+            await client.get(error_query, handle_retries=False)
+
+    # Requests are disallowed regardless of the query, and the same exception
+    # is reused for every subsequent call.
+    good_query = {"url": "https://a.example", "httpResponseBody": True}
+    with pytest.raises(TooManyUndocumentedErrors) as first:
+        await client.get(good_query)
+    with pytest.raises(TooManyUndocumentedErrors) as second:
+        await client.get(good_query)
+    assert first.value is second.value
+
+    # A separate client is unaffected.
+    other_client = AsyncZyteAPI(api_key="a", api_url=mockserver.urljoin("/"))
+    await other_client.get(good_query)

--- a/zyte_api/__init__.py
+++ b/zyte_api/__init__.py
@@ -3,7 +3,7 @@ Python client libraries and command line utilities for Zyte API
 """
 
 from ._async import AsyncZyteAPI, AuthInfo
-from ._errors import RequestError
+from ._errors import RequestError, TooManyUndocumentedErrors
 from ._retry import (
     AggressiveRetryFactory,
     RetryFactory,
@@ -31,6 +31,7 @@ __all__ = [
     "ParsedError",
     "RequestError",
     "RetryFactory",
+    "TooManyUndocumentedErrors",
     "ZyteAPI",
     "aggressive_retrying",
     "stop_after_uninterrupted_delay",

--- a/zyte_api/_async.py
+++ b/zyte_api/_async.py
@@ -13,7 +13,7 @@ from tenacity import AsyncRetrying
 from zyte_api._x402 import _x402Handler
 from zyte_api.apikey import NoApiKey, read_dotenv_auth
 
-from ._errors import RequestError
+from ._errors import RequestError, TooManyUndocumentedErrors
 from ._retry import zyte_api_retrying
 from ._utils import _AIO_API_TIMEOUT, create_session
 from .constants import API_URL
@@ -32,6 +32,11 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     _ResponseFuture = Awaitable[dict[str, Any]]
+
+# Undocumented error responses must reach both thresholds, in absolute number
+# and as a share of all requests sent, before a client stops sending requests.
+_UNDOCUMENTED_ERROR_MIN = 10
+_UNDOCUMENTED_ERROR_RATIO = 0.01
 
 
 def _post_func(
@@ -140,6 +145,7 @@ class AsyncZyteAPI:
         self.user_agent = user_agent or USER_AGENT
         self.trust_env = trust_env
         self._semaphore = asyncio.Semaphore(n_conn)
+        self._too_many_undocumented_errors: TooManyUndocumentedErrors | None = None
         self._auth: str | _x402Handler
         self.auth: AuthInfo
         self.api_url: str
@@ -196,6 +202,19 @@ class AsyncZyteAPI:
             "api_key is not available when using an Ethereum private key, use auth.key instead."
         )
 
+    def _check_undocumented_errors(self) -> None:
+        if self._too_many_undocumented_errors is not None:
+            raise self._too_many_undocumented_errors
+        errors = self.agg_stats._n_undocumented_errors
+        if (
+            errors >= _UNDOCUMENTED_ERROR_MIN
+            and errors >= _UNDOCUMENTED_ERROR_RATIO * self.agg_stats.n_attempts
+        ):
+            self._too_many_undocumented_errors = TooManyUndocumentedErrors(
+                errors, self.agg_stats.n_attempts
+            )
+            raise self._too_many_undocumented_errors
+
     async def get(
         self,
         query: dict[str, Any],
@@ -206,6 +225,8 @@ class AsyncZyteAPI:
         retrying: AsyncRetrying | None = None,
     ) -> dict[str, Any]:
         """Asynchronous equivalent to :meth:`ZyteAPI.get`."""
+        self._check_undocumented_errors()
+
         retrying = retrying or self.retrying
         owned_session: aiohttp.ClientSession | None = None
         if session is None:

--- a/zyte_api/_errors.py
+++ b/zyte_api/_errors.py
@@ -10,6 +10,29 @@ from zyte_api.errors import ParsedError
 logger = logging.getLogger("zyte_api")
 
 
+def _is_undocumented_status(status: int) -> bool:
+    # 503 is rate limiting, 520 and 521 are download errors.
+    return status >= 500 and status not in {503, 520, 521}
+
+
+class TooManyUndocumentedErrors(RuntimeError):
+    """Exception raised by a client that has received :ref:`too many
+    undocumented error responses <zapi-undocumented-error-limit>`.
+
+    .. versionadded:: VERSION
+    """
+
+    def __init__(self, errors: int, total: int):
+        super().__init__(
+            f"Too many undocumented error responses received from Zyte API "
+            f"({errors} out of {total}, {errors / total:.2%}). This client "
+            f"will not send any more Zyte API requests. Please, check "
+            f"https://status.zyte.com/ or contact support "
+            f"(https://support.zyte.com/support/tickets/new) before sending "
+            f"more requests like the ones causing these error responses."
+        )
+
+
 class RequestError(ClientResponseError):
     """Exception raised upon receiving a :ref:`rate-limiting
     <zapi-rate-limit>` or :ref:`unsuccessful

--- a/zyte_api/_retry.py
+++ b/zyte_api/_retry.py
@@ -25,7 +25,7 @@ from tenacity import (
 )
 from tenacity.stop import stop_base, stop_never
 
-from ._errors import RequestError
+from ._errors import RequestError, _is_undocumented_status
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -158,11 +158,7 @@ def _download_error(exc: BaseException) -> bool:
 
 
 def _undocumented_error(exc: BaseException) -> bool:
-    return (
-        isinstance(exc, RequestError)
-        and exc.status >= 500
-        and exc.status not in {503, 520, 521}
-    )
+    return isinstance(exc, RequestError) and _is_undocumented_status(exc.status)
 
 
 def _402_error(exc: BaseException) -> bool:

--- a/zyte_api/stats.py
+++ b/zyte_api/stats.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Optional
 import attr
 from runstats import Statistics
 
+from zyte_api._errors import _is_undocumented_status
 from zyte_api.errors import ParsedError
 
 if TYPE_CHECKING:
@@ -91,6 +92,14 @@ class AggStats:
     def n_processed(self) -> float:
         """Total number of processed URLs"""
         return self.n_success + self.n_fatal_errors
+
+    @property
+    def _n_undocumented_errors(self) -> int:
+        return sum(
+            count
+            for status, count in self.status_codes.items()
+            if _is_undocumented_status(status)
+        )
 
 
 @attr.s


### PR DESCRIPTION
Alternative to https://github.com/zytedata/python-zyte-api/pull/82.

Once merged and released, make changes in scrapy-zyte-api as well:

<details>
<summary>LLM plan</summary>

```
Post-merge work: scrapy-zyte-api

Once this is merged and released, scrapy-zyte-api needs to handle the new TooManyUndocumentedErrors exception. Without these changes the exception is swallowed into generic error paths and the spider keeps running, which defeats the purpose of the limit.

Scoping note: the limit is per AsyncZyteAPI instance, and scrapy-zyte-api builds exactly one, in the download handler. Providers (providers.py:410-414) and the session manager (_session.py:1047-1053) both send their requests through crawler.engine.download, so they all share that client and trip the limit together. There is no second client to worry about.

1. Close the spider — scrapy_zyte_api/handler.py

_download_request currently catches RequestError and then falls through to a generic except Exception that logs at debug level and re-raises (handler.py:326-333). TooManyUndocumentedErrors would land there, so every request would fail one at a time with a debug-level message.

Add a dedicated branch before the generic one, logging at error level and closing the spider, mirroring the existing zyte_api_bad_key / zyte_api_suspended_account handling in _process_request_error (handler.py:360-376):

except TooManyUndocumentedErrors as error:
    logger.error(str(error))
    _close_spider(self._crawler, "zyte_api_too_many_undocumented_errors")
    raise
_close_spider is already imported from .utils (handler.py:37).

2. Do not swallow it in the session manager — scrapy_zyte_api/_session.py

_init_session ends in except Exception: self._inc_stat("init/failed", pool); return False (_session.py:1111-1113). That would turn the new exception into a plain failed session init, and _create_session would keep looping (_session.py:1124-1139) until TooManyBadSessionInits, closing the spider with a misleading reason.

The file already re-raises CloseSpider explicitly right above (_session.py:1109-1110); add the new exception to that branch:

except (CloseSpider, TooManyUndocumentedErrors):
    raise
Check the other broad handlers in the same file while at it: _session.py:626, _session.py:668 and _session.py:1274.

3. Requirements

- pyproject.toml:30: zyte-api>=0.6.0 → the release that includes this.
- tox.ini: the pinned-lowest envs use zyte-api==0.6.0 (lines 75, 114, 124, 133) and zyte-api==0.8.1 (line 54); bump whichever must match the new minimum.

4. Docs and tests

- Document the new zyte_api_too_many_undocumented_errors close reason alongside the existing ones, and link to the zapi-undocumented-error-limit section of the python-zyte-api docs.
- Add a handler test asserting the finish reason, following tests/test_handler.py:649 and tests/test_handler.py:677.
```

</details>